### PR TITLE
use openjdk instead of oraclejdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala: ""
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 script:


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802

> oraclejdk8 is not preinstalled on Xenial anymore, and cannot be retrieved from Oracle itself anymore. We'd suggest using either openjdk, or the currently supported Oracle JDK.